### PR TITLE
feat: added version-aware sorting to improve version_list

### DIFF
--- a/lua/neonuget/ui/version_list.lua
+++ b/lua/neonuget/ui/version_list.lua
@@ -95,11 +95,32 @@ function M.create(opts)
 				data = version_obj,
 			})
 
+			local version_split = {}
+			local count = 1
+			for str in string.gmatch(version_text, "[^%.]+") do
+				version_split[count] = tonumber(str)
+				count = count + 1
+			end
+
+			table.insert(standardized_versions, {
+				text = version_text,
+				data = version_obj,
+				version_split = version_split,
+			})
+
 			::continue::
 		end
 
 		table.sort(standardized_versions, function(a, b)
-			return a.text > b.text
+			for index, value in ipairs(a.version_split) do
+				if b.version_split[index] == nil then
+					return true
+				end
+				if value ~= b.version_split[index] then
+					return value > b.version_split[index]
+				end
+			end
+			return false
 		end)
 
 		for i, v in ipairs(standardized_versions) do


### PR DESCRIPTION
Fixed the issue https://github.com/MonsieurTib/neonuget/issues/18 by replacing the basic string comparison logic for sorting the standardized_version table with a dedicated version-number comparison by splitting the version-string into substrings that contain major-, minor- & patch-versions.

I have tested this with semantic versions (including preview-tags) and also date-and-build-number-based versions.

<img width="2527" height="1170" alt="Screenshot 2026-01-28 at 00 55 20" src="https://github.com/user-attachments/assets/985d54ef-9f9d-4115-a8c1-9d26f5ebaf0c" />

I'm fairly new to lua programming so feel free to critique potentially awkward code :)